### PR TITLE
修复 gcc 下 warning 错误

### DIFF
--- a/port/RTTHardware.h
+++ b/port/RTTHardware.h
@@ -80,7 +80,7 @@ class RTTHardware {
 
     protected:
         long baud_;
-        char* deviceName_;
+        const char* deviceName_;
 };
 
 #endif


### PR DESCRIPTION
报错如下: 
```
./rtconfig.h:156:29: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
 #define ROSSERIAL_UART_NAME "uart5"
                             ^
rt-rosserial/port/RTTHardware.h:23:27: note: in expansion of macro 'ROSSERIAL_UART_NAME'
             deviceName_ = ROSSERIAL_UART_NAME;
                           ^~~~~~~~~~~~~~~~~~~
```

修改后无报错， 可以正常编译